### PR TITLE
Add optimistic EDR calculation to ComputeAgentData and MinerStats

### DIFF
--- a/econ/econ.go
+++ b/econ/econ.go
@@ -69,7 +69,10 @@ func ComputeAgentData(
 
 	/* ~~~~~ ExpectedDailyRewards ~~~~~ */
 
-	data.ExpectedDailyRewards = aggMinerStats.ExpectedDailyReward
+	// optimistically assume available agent balance will be pledged and subsidize the EDR
+	optimisticEdr := mstat.ComputeOptimisticEarnings(agentAvailableBalance, aggMinerStats.PledgedFunds, aggMinerStats.ExpectedDailyBlockReward)
+	// the Agent's expected daily rewards include its estimated block rewards (from pledged FIL + optimistically pledged FIL) and 1/180 vesting rewards
+	data.ExpectedDailyRewards = new(big.Int).Add(aggMinerStats.ExpectedDailyReward, optimisticEdr)
 
 	/* ~~~~~ GCRED (NOT IN USE) ~~~~~ */
 	data.Gcred = big.NewInt(100)

--- a/mstat/mstat_test.go
+++ b/mstat/mstat_test.go
@@ -55,7 +55,7 @@ func TestCmpWithOnChainSectorInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ComputeEDRLazy1(context.Background(), minerTest, ts, lapi)
+	_, err = ComputeBlockRewardsLazy(context.Background(), minerTest, ts, lapi)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Today, Agents have trouble borrowing enough FIL to reach their limits because of DTI checks. Agents who plan to use the FIL for sealing can't borrow enough to increase their rewards enough, to increase their earnings, to stay unrestricted. 

This PR changes the EDR calculation such that it optimistically treats available balances on the miner and the agent as pledged, just as we do for liquidation value calculations. 

The strategy is to compute a ratio of pledged fil : block rewards, and then apply that ratio to available balances.

Needs testing and before/after calculations to see the difference