### PR TITLE
Liquidation: increase number of samples for small miners

### DIFF
--- a/terminate/preview.go
+++ b/terminate/preview.go
@@ -116,6 +116,8 @@ func PreviewTerminateSectors(
 	progressCh chan *PreviewTerminateSectorsProgress,
 	resultCh chan *PreviewTerminateSectorsReturn,
 ) {
+	var desiredMinSamples uint64 = 600
+
 	h, ts, err := parseTipSetAndHeight(ctx, api, tipset, vmHeight)
 	if err != nil {
 		errorCh <- err
@@ -388,7 +390,8 @@ func PreviewTerminateSectors(
 							return
 						}
 						sampledSectors := make([]uint64, 0)
-						step := max(float64(len(sectors))/float64(batchSize-1), 1.0)
+						partitionBatchSize := max(batchSize, desiredMinSamples/uint64(len(deadlinePartitions)))
+						step := max(float64(len(sectors))/float64(partitionBatchSize-1), 1.0)
 						lastIndex := -1
 						for sampleIndex := 0.0; int(sampleIndex) < len(sectors); sampleIndex += step {
 							i := int(sampleIndex)

--- a/terminate/preview_quick.go
+++ b/terminate/preview_quick.go
@@ -34,6 +34,7 @@ func PreviewTerminateSectorsQuick(
 	ts *types.TipSet,
 ) (*PreviewTerminateSectorsReturn, error) {
 	var batchSize uint64 = 40
+	var desiredMinSamples uint64 = 600
 	var gasLimit uint64 = 270000000000
 	var maxPartitions uint64 = 21
 
@@ -217,7 +218,8 @@ func PreviewTerminateSectorsQuick(
 						return
 					}
 					sampledSectors := make([]uint64, 0)
-					step := max(float64(len(sectors))/float64(batchSize-1), 1.0)
+					partitionBatchSize := max(batchSize, desiredMinSamples/uint64(len(deadlinePartitions)))
+					step := max(float64(len(sectors))/float64(partitionBatchSize-1), 1.0)
 					lastIndex := -1
 					for sampleIndex := 0.0; int(sampleIndex) < len(sectors); sampleIndex += step {
 						i := int(sampleIndex)


### PR DESCRIPTION
For some of the smallest miners, this tweak will result in more sectors being selected for sampling. Because they have so few sectors, this sets a "desired" number of sectors to sample to 600, which is quick to process. This desired amount is divided by the number of sampled deadlines. Sometimes the deadlines don't have many sectors in them, so the actual number sampled may be less than 600.

Before:

```
Agent 2 @2892359: 1 miners, 2.000 FIL borrowed (via API)
  Agent 2: Miner 1/1 f01931245 @4057766: Quick method: 12.196 FIL (45 of 323 sectors, offchain, 0.8s)
  Agent 2: Miner 1/1 f01931245 @4057766: Sampled method: 12.196 FIL (45 of 323 sectors, onchain, 0.9s)
  Agent 2: Miner 1/1 f01931245 @4057766: Full method: 12.190 FIL (323 of 323 sectors, onchain, 1s)
  Agent 2: Miner 1/1 f01931245: Termination penalty via API: 12.129 FIL
  Agent 2: Miner 1/1 f01931245: Quick method overestimated: 0.006 FIL (0.050%, 0.302% of agent principal)
```

After:

```
Agent 2 @2892359: 1 miners, 2.000 FIL borrowed (via API)
  Agent 2: Miner 1/1 f01931245 @4061092: Quick method: 12.272 FIL (205 of 323 sectors, offchain, 0.8s)
  Agent 2: Miner 1/1 f01931245 @4061092: Sampled method: 12.272 FIL (205 of 323 sectors, onchain, 0.9s)
  Agent 2: Miner 1/1 f01931245 @4061092: Full method: 12.273 FIL (323 of 323 sectors, onchain, 1s)
  Agent 2: Miner 1/1 f01931245: Termination penalty via API: 12.272 FIL
  Agent 2: Miner 1/1 f01931245: Quick method UNDERESTIMATED: 0.001 FIL (0.010%, 0.062% of agent principal, 205/323 sectors)
```

The number of sectors sampled increased from just 45 to 205 for this miner.

This decreases the variance for several outliers (small miners) when comparing the quick method against terminating all the sectors. It shouldn't have much performance impact otherwise.