### PR TITLE
Add initial framework for margin helpers

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -39,6 +39,7 @@ var (
 	MethodPushFunds    Method = "pushFunds"
 	MethodPullFunds    Method = "pullFunds"
 	MethodSetRecovered Method = "setRecovered"
+	MethodDefaultDTL   Method = "setAgentDefaultDTL"
 )
 
 type Route string
@@ -74,3 +75,5 @@ var FAULTY_SECTOR_TOLERANCE = big.NewFloat(0.001)
 var MAX_DTE = big.NewInt(2e18)
 var MAX_LTV = big.NewInt(8e17)
 var MAX_DTI = big.NewInt(25e16)
+var MAX_BORROW_DTL = big.NewInt(75e16)
+var LIQUIDATION_DTL = big.NewInt(85e16)

--- a/terminate/margin.go
+++ b/terminate/margin.go
@@ -1,0 +1,54 @@
+package terminate
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/glifio/go-pools/constants"
+)
+
+func Margin(balance *big.Int, termPenalty *big.Int) (*big.Int, *big.Int, *big.Int) {
+	margin := big.NewInt(0).Sub(balance, termPenalty)
+
+	// calculate max borrow and seal as (margin * 1e18 / (1e18-borrowDTL)) - margin
+	maxBorrowAndSeal := big.NewInt(0).Sub(
+		big.NewInt(0).Div(
+			big.NewInt(0).Mul(margin, big.NewInt(1e18)),
+			big.NewInt(0).Sub(constants.WAD, constants.MAX_BORROW_DTL),
+		),
+		margin,
+	)
+
+	// calculate max borrow and withdraw as margin - ((margin * 25e16) / 1e18)
+	maxBorrowAndWithdraw := big.NewInt(0).Sub(margin, big.NewInt(0).Div(big.NewInt(0).Mul(margin, big.NewInt(25e16)), big.NewInt(1e18)))
+
+	return margin, maxBorrowAndSeal, maxBorrowAndWithdraw
+}
+
+func GetMinerMargin(ctx context.Context, api *api.FullNodeStruct, minerAddr address.Address, ts *types.TipSet) (*MinerMargin, error) {
+	termRes, err := EstimateTerminationPenalty(context.Background(), api, minerAddr, ts)
+	if err != nil {
+		return nil, err
+	}
+
+	margin, maxBorrowAndSeal, maxBorrowAndWithdraw := Margin(termRes.TotalBalance, termRes.EstimatedTerminationFee)
+
+	baseMargin := BaseMargin{
+		AvailableBalance:     termRes.AvailableBalance,
+		LockedRewards:        termRes.VestingFunds,
+		InitialPledge:        termRes.InitialPledge,
+		Margin:               margin,
+		TerminationPenalty:   termRes.EstimatedTerminationFee,
+		MaxBorrowAndSeal:     maxBorrowAndSeal,
+		MaxBorrowAndWithdraw: maxBorrowAndWithdraw,
+	}
+
+	return &MinerMargin{
+		BaseMargin:   baseMargin,
+		MinerAddr:    minerAddr,
+		MinerBalance: termRes.TotalBalance,
+	}, nil
+}

--- a/terminate/types.go
+++ b/terminate/types.go
@@ -54,6 +54,33 @@ type PreviewAgentTerminationSummary struct {
 	AgentAvailableBal  *big.Int
 }
 
+type BaseMargin struct {
+	AvailableBalance     *big.Int `json:"availableBalance"`
+	LockedRewards        *big.Int `json:"lockedRewards"`
+	InitialPledge        *big.Int `json:"initialPledge"`
+	Margin               *big.Int `json:"margin"`
+	TerminationPenalty   *big.Int `json:"terminationPenalty"`
+	MaxBorrowAndSeal     *big.Int `json:"maxBorrowAndSeal"`
+	MaxBorrowAndWithdraw *big.Int `json:"maxBorrowAndWithdraw"`
+}
+
+type AgentMargin struct {
+	BaseMargin
+	AgentId       *big.Int `json:"agentId"`
+	AgentBalance  *big.Int `json:"agentBalance"`
+	Principal     *big.Int `json:"principal"`
+	LeverageRatio float64  `json:"leverageRatio"`
+	BorrowLimit   *big.Int `json:"borrowLimit"`
+	WithdrawLimit *big.Int `json:"withdrawLimit"`
+	MarginCall    *big.Int `json:"marginCall"`
+}
+
+type MinerMargin struct {
+	BaseMargin
+	MinerAddr    address.Address `json:"minerAddr"`
+	MinerBalance *big.Int        `json:"minerBalance"`
+}
+
 type MinerCollateralStat struct {
 	Address            address.Address `json:"address"`
 	Total              *big.Int        `json:"total"`


### PR DESCRIPTION
@ganzai-san one thing to note here is in the `Margin` helper method, we use the total balance to calculate the margin, not just the initial pledge + vesting balance. That seems to make more sense to me